### PR TITLE
Fixes NameError

### DIFF
--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -332,6 +332,7 @@ import io
 from random import randint
 from time import sleep
 from tempfile import NamedTemporaryFile
+from sys import exit
 
 # constants/globals
 MSSB_URL = 'http://www.microsoft.com/en-gb/download/confirmation.aspx?id=36982'


### PR DESCRIPTION
Fixes the following error message:
 NameError: global name 'exit' is not defined
